### PR TITLE
Fix: Update `php-fpm` binary version on `run.sh`

### DIFF
--- a/alpine-php-wordpress-aarch64/Dockerfile
+++ b/alpine-php-wordpress-aarch64/Dockerfile
@@ -40,7 +40,7 @@ RUN sed -i 's/;cgi.fix_pathinfo=1/cgi.fix_pathinfo=0/g' /etc/php81/php.ini && \
     sed -i 's/expose_php = On/expose_php = Off/g' /etc/php81/php.ini && \
     sed -i "s/nginx:x:100:101:nginx:\/var\/lib\/nginx:\/sbin\/nologin/nginx:x:100:101:nginx:\/usr:\/bin\/bash/g" /etc/passwd && \
     sed -i "s/nginx:x:100:101:nginx:\/var\/lib\/nginx:\/sbin\/nologin/nginx:x:100:101:nginx:\/usr:\/bin\/bash/g" /etc/passwd- && \
-    ln -s /sbin/php-fpm8 /sbin/php-fpm
+    ln -s /sbin/php-fpm81 /sbin/php-fpm
 
 ADD files/nginx.conf /etc/nginx/
 ADD files/php-fpm.conf /etc/php81/

--- a/alpine-php-wordpress-aarch64/files/run.sh
+++ b/alpine-php-wordpress-aarch64/files/run.sh
@@ -16,7 +16,7 @@ chown -R nginx:www-data /usr/html
 
 # start php-fpm
 mkdir -p /usr/logs/php-fpm
-php-fpm8
+php-fpm81
 
 # start nginx
 mkdir -p /usr/logs/nginx

--- a/alpine-php-wordpress-amd64-s/Dockerfile
+++ b/alpine-php-wordpress-amd64-s/Dockerfile
@@ -90,7 +90,7 @@ RUN sed -i 's/;cgi.fix_pathinfo=1/cgi.fix_pathinfo=0/g' /etc/php81/php.ini && \
     sed -i 's/expose_php = On/expose_php = Off/g' /etc/php81/php.ini && \
     sed -i "s/nginx:x:100:101:nginx:\/var\/lib\/nginx:\/sbin\/nologin/nginx:x:100:101:nginx:\/usr:\/bin\/bash/g" /etc/passwd && \
     sed -i "s/nginx:x:100:101:nginx:\/var\/lib\/nginx:\/sbin\/nologin/nginx:x:100:101:nginx:\/usr:\/bin\/bash/g" /etc/passwd- && \
-    ln -s /sbin/php-fpm8 /sbin/php-fpm
+    ln -s /sbin/php-fpm81 /sbin/php-fpm
 
 ADD files/nginx.conf /etc/nginx/nginx.conf
 ADD files/php-fpm.conf /etc/php81/

--- a/alpine-php-wordpress-amd64-s/files/run.sh
+++ b/alpine-php-wordpress-amd64-s/files/run.sh
@@ -16,7 +16,7 @@ chown -R nginx:www-data /usr/html
 
 # start php-fpm
 mkdir -p /usr/logs/php-fpm
-php-fpm8
+php-fpm81
 
 # start nginx
 mkdir -p /usr/logs/nginx

--- a/alpine-php-wordpress-amd64/Dockerfile
+++ b/alpine-php-wordpress-amd64/Dockerfile
@@ -40,7 +40,7 @@ RUN sed -i 's/;cgi.fix_pathinfo=1/cgi.fix_pathinfo=0/g' /etc/php81/php.ini && \
     sed -i 's/expose_php = On/expose_php = Off/g' /etc/php81/php.ini && \
     sed -i "s/nginx:x:100:101:nginx:\/var\/lib\/nginx:\/sbin\/nologin/nginx:x:100:101:nginx:\/usr:\/bin\/bash/g" /etc/passwd && \
     sed -i "s/nginx:x:100:101:nginx:\/var\/lib\/nginx:\/sbin\/nologin/nginx:x:100:101:nginx:\/usr:\/bin\/bash/g" /etc/passwd- && \
-    ln -s /sbin/php-fpm8 /sbin/php-fpm
+    ln -s /sbin/php-fpm81 /sbin/php-fpm
 
 ADD files/nginx.conf /etc/nginx/
 ADD files/php-fpm.conf /etc/php81/

--- a/alpine-php-wordpress-amd64/files/run.sh
+++ b/alpine-php-wordpress-amd64/files/run.sh
@@ -16,7 +16,7 @@ chown -R nginx:www-data /usr/html
 
 # start php-fpm
 mkdir -p /usr/logs/php-fpm
-php-fpm8
+php-fpm81
 
 # start nginx
 mkdir -p /usr/logs/nginx

--- a/alpine-php-wordpress-armhf/Dockerfile
+++ b/alpine-php-wordpress-armhf/Dockerfile
@@ -40,7 +40,7 @@ RUN sed -i 's/;cgi.fix_pathinfo=1/cgi.fix_pathinfo=0/g' /etc/php81/php.ini && \
     sed -i 's/expose_php = On/expose_php = Off/g' /etc/php81/php.ini && \
     sed -i "s/nginx:x:100:101:nginx:\/var\/lib\/nginx:\/sbin\/nologin/nginx:x:100:101:nginx:\/usr:\/bin\/bash/g" /etc/passwd && \
     sed -i "s/nginx:x:100:101:nginx:\/var\/lib\/nginx:\/sbin\/nologin/nginx:x:100:101:nginx:\/usr:\/bin\/bash/g" /etc/passwd- && \
-    ln -s /sbin/php-fpm8 /sbin/php-fpm
+    ln -s /sbin/php-fpm81 /sbin/php-fpm
 
 ADD files/nginx.conf /etc/nginx/
 ADD files/php-fpm.conf /etc/php81/

--- a/alpine-php-wordpress-armhf/files/run.sh
+++ b/alpine-php-wordpress-armhf/files/run.sh
@@ -16,7 +16,7 @@ chown -R nginx:www-data /usr/html
 
 # start php-fpm
 mkdir -p /usr/logs/php-fpm
-php-fpm8
+php-fpm81
 
 # start nginx
 mkdir -p /usr/logs/nginx


### PR DESCRIPTION
I think from the time the last PR was created the version of `php-fpm` bumped from 8 to 8.1, therefore it was still not working.